### PR TITLE
Add serialization methods for NavigationResult

### DIFF
--- a/core/src/earth.rs
+++ b/core/src/earth.rs
@@ -353,6 +353,21 @@ pub fn gravitation(latitude: &f64, longitude: &f64, altitude: &f64) -> Vector3<f
     gravity + rot * omega_ie * omega_ie * ecef_vec
 }
 /// Calculate local gravity anomaly from IMU accelerometer measurements
+/// 
+/// This function calculates the local gravity anomaly by comparing the observed gravity from the
+/// IMU accelerometer measurements (eg: $\sqrt(a_x^2 + a_y^2 + a_z^2)$) with the normal gravity 
+/// at the given latitude and altitude via the Somigliana method. Additionally, this function 
+/// compensates for the motion of the platform (if any) using the Eötvös correction.
+/// 
+/// # Parameters
+/// - `latitude` - The WGS84 latitude in degrees
+/// - `altitude` - The WGS84 altitude in meters
+/// - `north_velocity` - The northward velocity component in m/s
+/// - `east_velocity` - The eastward velocity component in m/s
+/// - `gravity_observed` - The observed gravity from the IMU accelerometer measurements in m/s^2
+/// 
+/// # Returns
+/// The local gravity anomaly in m/s^2, which is the difference between the observed gravity and the normal gravity at the given latitude and altitude, adjusted for the Eötvös correction.
 pub fn gravity_anomaly(
     latitude: &f64,
     altitude: &f64,

--- a/core/src/sim.rs
+++ b/core/src/sim.rs
@@ -754,6 +754,7 @@ impl
         }
     }
 }
+
 /// Run dead reckoning or "open-loop" simulation using test data.
 ///
 /// This function processes a sequence of sensor records through a StrapdownState, using


### PR DESCRIPTION
Implement serialization methods for the `NavigationResult` struct to facilitate writing results to CSV. This change enhances the functionality of the application by allowing results to be easily exported. The previous write function has been replaced with a call to the new serialization methods.

Fixes #52