### PR TITLE
Refactor StrapdownState to use Default and new() properly

### DIFF
--- a/core/src/sim.rs
+++ b/core/src/sim.rs
@@ -1246,7 +1246,7 @@ mod tests {
     }
     #[test]
     fn test_navigation_result_new_from_nav_state() {
-        let mut state = StrapdownState::new();
+        let mut state = StrapdownState::default();
         state.latitude = 1.0;
         state.longitude = 2.0;
         state.altitude = 3.0;


### PR DESCRIPTION
Refactor the `StrapdownState` implementation to utilize the `Default` trait correctly, ensuring that `new()` includes proper input validation. This change improves the consistency and reliability of state initialization.

Fixes #65