### PR TITLE
Improve magnetic anomaly calculation and refactor navigation data structures

### DIFF
--- a/core/src/earth.rs
+++ b/core/src/earth.rs
@@ -687,7 +687,7 @@ pub fn magnetic_anomaly(
     mag_y: f64,
     mag_z: f64,
 ) -> f64 {
-    0.0 * latitude * longitude * altitude * mag_x * mag_y * mag_z // Placeholder for magnetic anomaly calculation
+    f64::NAN * latitude * longitude * altitude * mag_x * mag_y * mag_z // Placeholder for magnetic anomaly calculation to squash warnings
 }
 // === Unit tests ===
 #[cfg(test)]

--- a/core/src/sim.rs
+++ b/core/src/sim.rs
@@ -13,12 +13,13 @@
 //! can also be used to simulate various types of GNSS-denied scenarios, such as intermittent, degraded,
 //! or intermitent and degraded GNSS via the measurement models provided in this module. You can install 
 //! the programs that execute this generic simulation by installing the binary via `cargo install strapdown-rs`.
+use core::f64;
 use std::fmt::Display;
 use std::io::{self};
 use std::path::Path;
 
 use chrono::{DateTime, Utc};
-use nalgebra::{DMatrix, DVector};
+use nalgebra::{DMatrix, DVector, Vector3};
 use serde::{Deserialize, Serialize};
 
 use crate::earth;
@@ -193,6 +194,28 @@ impl Display for TestDataRecord {
         )
     }
 }
+
+// ==== Helper structus for navigation simulations ====
+/// Struct representing the covariance diagonal of a navigation solution in NED coordinates.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct NEDCovariance {
+    pub latitude_cov: f64,
+    pub longitude_cov: f64,
+    pub altitude_cov: f64,
+    pub velocity_n_cov: f64,
+    pub velocity_e_cov: f64,
+    pub velocity_d_cov: f64,
+    pub roll_cov: f64,
+    pub pitch_cov: f64,
+    pub yaw_cov: f64,
+    pub acc_bias_x_cov: f64,
+    pub acc_bias_y_cov: f64,
+    pub acc_bias_z_cov: f64,
+    pub gyro_bias_x_cov: f64,
+    pub gyro_bias_y_cov: f64,
+    pub gyro_bias_z_cov: f64,
+}
+
 /// Generic result struct for navigation simulations.
 ///
 /// This structure contains a single row of position, velocity, and attitude vectors
@@ -294,12 +317,6 @@ pub struct NavigationResult {
 }
 impl Default for NavigationResult {
     fn default() -> Self {
-        Self::new()
-    }
-}
-impl NavigationResult {
-    /// Creates a new NavigationResult with default values.
-    pub fn new() -> Self {
         NavigationResult {
             timestamp: Utc::now(),
             latitude: 0.0,
@@ -346,171 +363,13 @@ impl NavigationResult {
             mag_anomaly: -30.0,                    // default magnetic anomaly in nT
         }
     }
-    /// Creates a new NavigationResult from a StrapdownState, and covariance.
-    ///
-    /// This function takes a StrapdownState and a INS filter covariance matrix, and
-    /// constructs a NavigationResult with the state values and covariance.
-    ///
-    /// # Arguments
-    /// * `state` - StrapdownState containing the current state of the navigation system
-    /// * `timestamp` - DateTime<Utc>, the timestamp of the navigation solution
-    pub fn new_from_nav_state(
-        state: &StrapdownState,
-        timestamp: DateTime<Utc>,
-        acc_bias_x: f64,
-        acc_bias_y: f64,
-        acc_bias_z: f64,
-        gyro_bias_x: f64,
-        gyro_bias_y: f64,
-        gyro_bias_z: f64,
-        latitude_cov: f64,
-        longitude_cov: f64,
-        altitude_cov: f64,
-        velocity_n_cov: f64,
-        velocity_e_cov: f64,
-        velocity_d_cov: f64,
-        roll_cov: f64,
-        pitch_cov: f64,
-        yaw_cov: f64,
-        acc_bias_x_cov: f64,
-        acc_bias_y_cov: f64,
-        acc_bias_z_cov: f64,
-        gyro_bias_x_cov: f64,
-        gyro_bias_y_cov: f64,
-        gyro_bias_z_cov: f64,
-        acc_x: f64,
-        acc_y: f64,
-        acc_z: f64,
-        gyro_x: f64,
-        gyro_y: f64,
-        gyro_z: f64,
-        mag_x: f64,
-        mag_y: f64,
-        mag_z: f64,
-        pressure: f64,
-        freeair: f64,
-        mag_anomaly: f64,
-    ) -> Self {
-        NavigationResult {
-            timestamp,
-            latitude: state.latitude,
-            longitude: state.longitude,
-            altitude: state.altitude,
-            velocity_north: state.velocity_north,
-            velocity_east: state.velocity_east,
-            velocity_down: state.velocity_down,
-            roll: state.attitude.euler_angles().0,
-            pitch: state.attitude.euler_angles().1,
-            yaw: state.attitude.euler_angles().2,
-            acc_bias_x,
-            acc_bias_y,
-            acc_bias_z,
-            gyro_bias_x,
-            gyro_bias_y,
-            gyro_bias_z,
-            latitude_cov,
-            longitude_cov,
-            altitude_cov,
-            velocity_n_cov,
-            velocity_e_cov,
-            velocity_d_cov,
-            roll_cov,
-            pitch_cov,
-            yaw_cov,
-            acc_bias_x_cov,
-            acc_bias_y_cov,
-            acc_bias_z_cov,
-            gyro_bias_x_cov,
-            gyro_bias_y_cov,
-            gyro_bias_z_cov,
-            acc_x,
-            acc_y,
-            acc_z,
-            gyro_x,
-            gyro_y,
-            gyro_z,
-            mag_x,
-            mag_y,
-            mag_z,
-            pressure,
-            freeair,
-            mag_anomaly,
-        }
-    }
-    /// Creates a new NavigationResult from an nalgebra vector and covariance.
-    ///
-    /// This function creates a NavigationResult directly from a DVector representing the 9-state NED navigation solution,
-    /// and an optional covariance matrix.
-    ///
-    /// # Arguments
-    /// * `state` - DVector containing the navigation state (latitude, longitude, altitude, velocity_n, velocity_e, velocity_d, roll, pitch, yaw)
-    /// * `timestamp` - Timestamp of the navigation solution
-    /// * `covariance` - Optional DMatrix representing the covariance of the state
-    ///
-    /// # Returns
-    /// * `NavigationResult` - A new NavigationResult instance with the state values and covariance.
-    pub fn new_from_vector(
-        timestamp: DateTime<Utc>,
-        state: &DVector<f64>,
-        covariance: Option<&DMatrix<f64>>,
-        imu_data: &IMUData,
-        mag_x: f64,
-        mag_y: f64,
-        mag_z: f64,
-        pressure: f64,
-        freeair: f64,
-        mag_anomaly: f64,
-    ) -> Self {
-        let covariance_vec = match covariance {
-            Some(cov) => cov.diagonal().iter().cloned().collect(),
-            None => vec![0.0; state.len()],
-        };
-        NavigationResult {
-            timestamp,
-            latitude: state[0],
-            longitude: state[1],
-            altitude: state[2],
-            velocity_north: state[3],
-            velocity_east: state[4],
-            velocity_down: state[5],
-            roll: state[6],
-            pitch: state[7],
-            yaw: state[8],
-            acc_bias_x: state[9],
-            acc_bias_y: state[10],
-            acc_bias_z: state[11],
-            gyro_bias_x: state[12],
-            gyro_bias_y: state[13],
-            gyro_bias_z: state[14],
-            latitude_cov: covariance_vec.first().cloned().unwrap_or(0.0),
-            longitude_cov: covariance_vec.get(1).cloned().unwrap_or(0.0),
-            altitude_cov: covariance_vec.get(2).cloned().unwrap_or(0.0),
-            velocity_n_cov: covariance_vec.get(3).cloned().unwrap_or(0.0),
-            velocity_e_cov: covariance_vec.get(4).cloned().unwrap_or(0.0),
-            velocity_d_cov: covariance_vec.get(5).cloned().unwrap_or(0.0),
-            roll_cov: covariance_vec.get(6).cloned().unwrap_or(0.0),
-            pitch_cov: covariance_vec.get(7).cloned().unwrap_or(0.0),
-            yaw_cov: covariance_vec.get(8).cloned().unwrap_or(0.0),
-            acc_bias_x_cov: covariance_vec.get(9).cloned().unwrap_or(0.0),
-            acc_bias_y_cov: covariance_vec.get(10).cloned().unwrap_or(0.0),
-            acc_bias_z_cov: covariance_vec.get(11).cloned().unwrap_or(0.0),
-            gyro_bias_x_cov: covariance_vec.get(12).cloned().unwrap_or(0.0),
-            gyro_bias_y_cov: covariance_vec.get(13).cloned().unwrap_or(0.0),
-            gyro_bias_z_cov: covariance_vec.get(14).cloned().unwrap_or(0.0),
-            acc_x: imu_data.accel[0],
-            acc_y: imu_data.accel[1],
-            acc_z: imu_data.accel[2],
-            gyro_x: imu_data.gyro[0],
-            gyro_y: imu_data.gyro[1],
-            gyro_z: imu_data.gyro[2],
-            mag_x,
-            mag_y,
-            mag_z,
-            pressure,
-            freeair,
-            mag_anomaly,
-        }
-    }
+}
+impl NavigationResult {
+    /// Creates a new NavigationResult with default values.
+    pub fn new() -> Self {
+        // TODO: #70 Re-implement NavigationResult construcutor with validation
+        NavigationResult::default() // add in validation
+    }    
     /// Writes the NavigationResult to a CSV file.
     ///
     /// # Arguments
@@ -547,23 +406,125 @@ impl NavigationResult {
         Ok(records)
     }
 }
-/// Convert NED UKF to NavigationResult.
-impl From<(&DateTime<Utc>, &UKF, &IMUData, &f64, &f64, &f64, &f64)> for NavigationResult {
-    fn from(
-        (timestamp, ukf, imu_data, mag_x, mag_y, mag_z, pressure): (
+/// Convert DVectors containing the navigation state mean and covariance into a NavigationResult
+/// struct.
+/// 
+/// This implementation is useful for converting the output of a Kalman filter or UKF into a
+/// NavigationResult, which can then be used for further processing or analysis.
+/// 
+/// # Arguments
+/// - `timestamp`: The timestamp of the navigation solution.
+/// - `state`: A DVector containing the navigation state mean.
+/// - `covariance`: A DMatrix containing the covariance of the state.
+/// - `imu_data`: An IMUData struct containing the IMU measurements.
+/// - `mag_x`, `mag_y`, `mag_z`: Magnetic field strength in microteslas.
+/// - `pressure`: Pressure in millibars.
+/// - `freeair`: Free-air gravity anomaly in mGal.
+/// 
+/// # Returns
+/// A NavigationResult struct containing the navigation solution.
+impl From<(&DateTime<Utc>, &DVector<f64>, &DMatrix<f64>, &IMUData, &Vector3<f64>, &f64)> for NavigationResult {
+    fn from (
+        (timestamp, state, covariance, imu_data, magnetic_vector, pressure): (
             &DateTime<Utc>,
-            &UKF,
+            &DVector<f64>,
+            &DMatrix<f64>,
             &IMUData,
-            &f64,
-            &f64,
-            &f64,
+            &Vector3<f64>,
             &f64,
         ),
     ) -> Self {
-        let state = ukf.get_mean();
-        let covariance = ukf.get_covariance();
+        assert!(state.len() == 15, "State vector must have 15 elements");
+        assert!(covariance.nrows() == 15 && covariance.ncols() == 15, "Covariance matrix must be 15x15");
+        let covariance = DVector::from_vec(covariance.diagonal().iter().map(|&x| x).collect());
         NavigationResult {
             timestamp: *timestamp,
+            latitude: state[0].to_degrees(),
+            longitude: state[1].to_degrees(),
+            altitude: state[2],
+            velocity_north: state[3],
+            velocity_east: state[4],
+            velocity_down: state[5],
+            roll: state[6],
+            pitch: state[7],
+            yaw: state[8],
+            acc_bias_x: state[9],
+            acc_bias_y: state[10],
+            acc_bias_z: state[11],
+            gyro_bias_x: state[12],
+            gyro_bias_y: state[13],
+            gyro_bias_z: state[14],
+            latitude_cov: covariance[0],
+            longitude_cov: covariance[1],
+            altitude_cov: covariance[2],
+            velocity_n_cov: covariance[3],
+            velocity_e_cov: covariance[4],
+            velocity_d_cov: covariance[5],
+            roll_cov: covariance[6],
+            pitch_cov: covariance[7],
+            yaw_cov: covariance[8],
+            acc_bias_x_cov: covariance[9],
+            acc_bias_y_cov: covariance[10],
+            acc_bias_z_cov: covariance[11],
+            gyro_bias_x_cov: covariance[12],
+            gyro_bias_y_cov: covariance[13],
+            gyro_bias_z_cov: covariance[14],
+            acc_x: imu_data.accel[0],
+            acc_y: imu_data.accel[1],
+            acc_z: imu_data.accel[2],
+            gyro_x: imu_data.gyro[0],
+            gyro_y: imu_data.gyro[1],
+            gyro_z: imu_data.gyro[2],
+            mag_x: magnetic_vector.x,
+            mag_y: magnetic_vector.y,
+            mag_z: magnetic_vector.z,
+            pressure: *pressure,
+            freeair: earth::gravity_anomaly(
+                &state[0],
+                &state[2], // altitude
+                &state[3], // velocity_north
+                &state[4], // velocity_east
+                &(imu_data.accel[0].powi(2) + imu_data.accel[1].powi(2) + imu_data.accel[2].powi(2)).sqrt(),
+            ),
+            mag_anomaly: earth::magnetic_anomaly(
+                state[0].to_radians(),
+                state[1].to_radians(),
+                state[2], // altitude
+                magnetic_vector.x,
+                magnetic_vector.y,
+                magnetic_vector.z,
+            ),
+        }
+    }
+}
+/// Convert NED UKF to NavigationResult.
+/// 
+/// This implementation is useful for converting the output of a UKF into a
+/// NavigationResult, which can then be used for further processing or analysis.
+/// 
+/// # Arguments
+/// - `timestamp`: The timestamp of the navigation solution.
+/// - `ukf`: A reference to the UKF instance containing the navigation state mean and covariance.
+/// - `imu_data`: An IMUData struct containing the IMU measurements.
+/// - `magnetic_vector`: Magnetic field strength measurement in microteslas (body frame x, y, z).
+/// - `pressure`: Pressure in millibars.
+/// 
+/// # Returns
+/// A NavigationResult struct containing the navigation solution.
+impl From<(&DateTime<Utc>, &UKF, &IMUData, &Vector3<f64>, &f64)> for NavigationResult {
+    fn from(
+        (timestamp, ukf, imu_data, magnetic_vector, pressure): (
+            &DateTime<Utc>,
+            &UKF,
+            &IMUData,
+            &Vector3<f64>,
+            &f64,
+        ),
+    ) -> Self {
+        let state = &ukf.get_mean();
+        let covariance = ukf.get_covariance();
+        NavigationResult {
+            timestamp: timestamp.clone(),
             latitude: state[0].to_degrees(),
             longitude: state[1].to_degrees(),
             altitude: state[2],
@@ -600,57 +561,53 @@ impl From<(&DateTime<Utc>, &UKF, &IMUData, &f64, &f64, &f64, &f64)> for Navigati
             gyro_x: imu_data.gyro[0],
             gyro_y: imu_data.gyro[1],
             gyro_z: imu_data.gyro[2],
-            mag_x: *mag_x,
-            mag_y: *mag_y,
-            mag_z: *mag_z,
+            mag_x: magnetic_vector.x,
+            mag_y: magnetic_vector.y,
+            mag_z: magnetic_vector.z,
             pressure: *pressure,
             freeair: earth::gravity_anomaly(
-                &state[0].to_radians(),
-                &state[2],
-                &state[3],
-                &state[4],
-                &(imu_data.accel[0].powi(2)
-                    + imu_data.accel[1].powi(2)
-                    + imu_data.accel[2].powi(2))
-                .sqrt(),
+                &state[0],
+                &state[2], // altitude
+                &state[3], // velocity_north
+                &state[4], // velocity_east
+                &(imu_data.accel[0].powi(2) + imu_data.accel[1].powi(2) + imu_data.accel[2].powi(2)).sqrt(),
             ),
             mag_anomaly: earth::magnetic_anomaly(
                 state[0].to_radians(),
                 state[1].to_radians(),
-                state[2],
-                *mag_x,
-                *mag_y,
-                *mag_z,
-            ),
+                state[2], // altitude   
+                magnetic_vector.x,
+                magnetic_vector.y,
+                magnetic_vector.z,
+            ),  
         }
     }
 }
-impl
-    From<(
-        &DateTime<Utc>,
-        &StrapdownState,
-        &IMUData,
-        &f64,
-        &f64,
-        &f64,
-        &f64,
-    )> for NavigationResult
-{
+/// Convert StrapdownState to NavigationResult.
+/// 
+/// This implementation is useful for converting the output of a StrapdownState into a
+/// NavigationResult, which can then be used for further processing or analysis.
+/// 
+/// # Arguments
+/// - `timestamp`: The timestamp of the navigation solution.
+/// - `state`: A reference to the StrapdownState instance containing the navigation state.
+/// - `imu_data`: An IMUData struct containing the IMU measurements.
+/// - `magnetic_vector`: Magnetic field strength measurement in microteslas (body frame x, y, z).
+/// - `pressure`: Pressure in millibars.
+/// # Returns
+/// A NavigationResult struct containing the navigation solution.
+impl From<(&DateTime<Utc>, &StrapdownState, &IMUData, &Vector3<f64>, &f64)> for NavigationResult {
     fn from(
-        (timestamp, state, imu_data, mag_x, mag_y, mag_z, pressure): (
+        (timestamp, state, imu_data, magnetic_vector, pressure): (
             &DateTime<Utc>,
             &StrapdownState,
             &IMUData,
-            &f64,
-            &f64,
-            &f64,
+            &Vector3<f64>,
             &f64,
         ),
     ) -> Self {
-        //let state = ukf.get_mean();
-        //let covariance = ukf.get_covariance();
         NavigationResult {
-            timestamp: *timestamp,
+            timestamp: timestamp.clone(),
             latitude: state.latitude.to_degrees(),
             longitude: state.longitude.to_degrees(),
             altitude: state.altitude,
@@ -660,55 +617,52 @@ impl
             roll: state.attitude.euler_angles().0,
             pitch: state.attitude.euler_angles().1,
             yaw: state.attitude.euler_angles().2,
-            acc_bias_x: 0.0,
+            acc_bias_x: 0.0, // StrapdownState does not store biases
             acc_bias_y: 0.0,
             acc_bias_z: 0.0,
             gyro_bias_x: 0.0,
             gyro_bias_y: 0.0,
             gyro_bias_z: 0.0,
-            latitude_cov: 0.0,
-            longitude_cov: 0.0,
-            altitude_cov: 0.0,
-            velocity_n_cov: 0.0,
-            velocity_e_cov: 0.0,
-            velocity_d_cov: 0.0,
-            roll_cov: 0.0,
-            pitch_cov: 0.0,
-            yaw_cov: 0.0,
-            acc_bias_x_cov: 0.0,
-            acc_bias_y_cov: 0.0,
-            acc_bias_z_cov: 0.0,
-            gyro_bias_x_cov: 0.0,
-            gyro_bias_y_cov: 0.0,
-            gyro_bias_z_cov: 0.0,
+            latitude_cov: f64::NAN, // default covariance values
+            longitude_cov: f64::NAN,
+            altitude_cov: f64::NAN,
+            velocity_n_cov: f64::NAN,
+            velocity_e_cov: f64::NAN,
+            velocity_d_cov: f64::NAN,
+            roll_cov: f64::NAN,
+            pitch_cov: f64::NAN,
+            yaw_cov: f64::NAN,
+            acc_bias_x_cov: f64::NAN, 
+            acc_bias_y_cov: f64::NAN,
+            acc_bias_z_cov: f64::NAN,
+            gyro_bias_x_cov: f64::NAN,
+            gyro_bias_y_cov: f64::NAN,
+            gyro_bias_z_cov: f64::NAN,
             acc_x: imu_data.accel[0],
             acc_y: imu_data.accel[1],
             acc_z: imu_data.accel[2],
             gyro_x: imu_data.gyro[0],
             gyro_y: imu_data.gyro[1],
             gyro_z: imu_data.gyro[2],
-            mag_x: *mag_x,
-            mag_y: *mag_y,
-            mag_z: *mag_z,
+            mag_x: magnetic_vector.x,
+            mag_y: magnetic_vector.y,
+            mag_z: magnetic_vector.z,
             pressure: *pressure,
             freeair: earth::gravity_anomaly(
                 &state.latitude,
                 &state.altitude,
                 &state.velocity_north,
                 &state.velocity_east,
-                &(imu_data.accel[0].powi(2)
-                    + imu_data.accel[1].powi(2)
-                    + imu_data.accel[2].powi(2))
-                .sqrt(),
+                &(imu_data.accel[0].powi(2) + imu_data.accel[1].powi(2) + imu_data.accel[2].powi(2)).sqrt(),
             ),
             mag_anomaly: earth::magnetic_anomaly(
-                state.latitude,
-                state.longitude,
+                state.latitude.to_radians(),
+                state.longitude.to_radians(),
                 state.altitude,
-                *mag_x,
-                *mag_y,
-                *mag_z,
-            ),
+                magnetic_vector.x,
+                magnetic_vector.y,
+                magnetic_vector.z,
+            ),  
         }
     }
 }
@@ -758,21 +712,17 @@ pub fn dead_reckoning(records: &[TestDataRecord]) -> Vec<NavigationResult> {
     };
     // Store the initial state and metadata
     results.push(NavigationResult::from((
-        &records[0].time,
-        &state,
-        &IMUData::new_from_vec(
-            vec![first_record.acc_x, first_record.acc_y, first_record.acc_z],
-            vec![
-                first_record.gyro_x,
-                first_record.gyro_y,
-                first_record.gyro_z,
-            ],
-        ),
-        &first_record.mag_x,
-        &first_record.mag_y,
-        &first_record.mag_z,
+        &first_record.time,
+        &state.into(),
+        &DMatrix::from_diagonal(&DVector::from_element(15, 0.0)),
+        &IMUData {
+            accel: Vector3::new(first_record.acc_x, first_record.acc_y, first_record.acc_z),
+            gyro: Vector3::new(first_record.gyro_x, first_record.gyro_y, first_record.gyro_z),
+        },
+        &Vector3::new( first_record.mag_x, first_record.mag_y, first_record.mag_z),
         &first_record.pressure,
-    )));
+    )
+    ));
     let mut previous_time = records[0].time;
     // Process each subsequent record
     for record in records.iter().skip(1) {
@@ -780,18 +730,21 @@ pub fn dead_reckoning(records: &[TestDataRecord]) -> Vec<NavigationResult> {
         let current_time = record.time;
         let dt = (current_time - previous_time).as_seconds_f64();
         // Create IMU data from the record
-        let imu_data = IMUData::new_from_vec(
-            vec![record.acc_x, record.acc_y, record.acc_z],
-            vec![record.gyro_x, record.gyro_y, record.gyro_z],
-        );
+        let imu_data = IMUData {
+            accel: Vector3::new(record.acc_x, record.acc_y, record.acc_z),
+            gyro: Vector3::new(record.gyro_x, record.gyro_y, record.gyro_z),
+        };
         forward(&mut state, imu_data, dt);
         results.push(NavigationResult::from((
             &current_time,
-            &state,
+            &state.into(),
+            &DMatrix::from_diagonal(&DVector::from_element(15, 0.0)),
             &imu_data,
-            &record.mag_x,
-            &record.mag_y,
-            &record.mag_z,
+            &Vector3::new(
+                record.mag_x,
+                record.mag_y,
+                record.mag_z,
+            ),
             &record.pressure,
         )));
         previous_time = record.time;
@@ -825,21 +778,15 @@ pub fn closed_loop(
     results.push(NavigationResult::from((
         &records[0].time,
         &ukf,
-        &IMUData::new_from_vec(
-            vec![
-                records[0].acc_x, // initial accelerometer data
-                records[0].acc_y,
-                records[0].acc_z,
-            ],
-            vec![
-                records[0].gyro_x, // initial gyroscope data
-                records[0].gyro_y,
-                records[0].gyro_z,
-            ],
+        &IMUData {
+            accel: Vector3::new(records[0].acc_x, records[0].acc_y, records[0].acc_z),
+            gyro: Vector3::new(records[0].gyro_x, records[0].gyro_y, records[0].gyro_z),
+        },
+        &Vector3::new(
+            records[0].mag_x,
+            records[0].mag_y,
+            records[0].mag_z,
         ),
-        &records[0].mag_x,
-        &records[0].mag_y,
-        &records[0].mag_z,
         &records[0].pressure,
     )));
     let mut previous_timestamp = records[0].time;
@@ -862,18 +809,18 @@ pub fn closed_loop(
         let dt = (current_timestamp - previous_timestamp).as_seconds_f64();
         // Create IMU data from the record subtracting out biases
         let mean = ukf.get_mean();
-        let imu_data = IMUData::new_from_vec(
-            vec![
+        let imu_data = IMUData {
+            accel: Vector3::new(
                 record.acc_x - mean[9], // subtract accel bias
                 record.acc_y - mean[10],
                 record.acc_z - mean[11],
-            ],
-            vec![
+            ),
+            gyro: Vector3::new(
                 record.gyro_x - mean[12], // subtract gyro bias
                 record.gyro_y - mean[13],
                 record.gyro_z - mean[14],
-            ],
-        );
+            ),
+        };
         // Update the UKF with the IMU data
         ukf.predict(imu_data, dt);
         // ---- Perform various measurement updates based on the available data ----
@@ -916,9 +863,11 @@ pub fn closed_loop(
             &current_timestamp,
             &ukf,
             &imu_data,
-            &record.mag_x,
-            &record.mag_y,
-            &record.mag_z,
+            &Vector3::new(
+                record.mag_x,
+                record.mag_y,
+                record.mag_z,
+            ),
             &record.pressure,
         )));
         i += 1;
@@ -1261,7 +1210,7 @@ mod tests {
     }
     #[test]
     fn test_navigation_result_new() {
-        let nav = NavigationResult::new();
+        let nav = NavigationResult::default();
         //let expected_timestamp = chrono::Utc::now();
         //assert_eq!(nav.timestamp, expected_timestamp);
         assert_eq!(nav.latitude, 0.0);
@@ -1272,8 +1221,8 @@ mod tests {
         assert_eq!(nav.velocity_down, 0.0);
     }
     #[test]
-    fn test_navigation_result_new_from_nav_state() {
-        let mut state = StrapdownState::new();
+    fn test_navigation_result_from_strapdown_state() {
+        let mut state = StrapdownState::default();
         state.latitude = 1.0;
         state.longitude = 2.0;
         state.altitude = 3.0;
@@ -1281,14 +1230,34 @@ mod tests {
         state.velocity_east = 5.0;
         state.velocity_down = 6.0;
         state.attitude = nalgebra::Rotation3::from_euler_angles(7.0, 8.0, 9.0);
+
+        let state_vector: DVector<f64> = DVector::from_vec(vec![
+            state.latitude,
+            state.longitude,
+            state.altitude,
+            state.velocity_north,
+            state.velocity_east,
+            state.velocity_down,
+            state.attitude.euler_angles().0, // roll
+            state.attitude.euler_angles().1, // pitch
+            state.attitude.euler_angles().2, // yaw
+            0.0, // acc_bias_x
+            0.0, // acc_bias_y
+            0.0, // acc_bias_z
+            0.0, // gyro_bias_x
+            0.0, // gyro_bias_y
+            0.0, // gyro_bias_z
+        ]);
         let timestamp = chrono::Utc::now();
         let nav = NavigationResult::from((
             &timestamp,
-            &state,
-            &IMUData::new_from_vec(vec![0.0; 3], vec![0.0; 3]),
-            &0.0,
-            &0.0,
-            &0.0,
+            &state_vector.into(),
+            &DMatrix::from_diagonal(&DVector::from_element(15, 0.0)), // dummy covariance
+            &IMUData {
+                accel: Vector3::new(0.0, 0.0, 0.0), // dummy IMU data
+                gyro: Vector3::new(0.0, 0.0, 0.0),
+            },
+            &Vector3::new(0.0, 0.0, 0.0), // dummy magnetic vector
             &1000.0, // dummy pressure
         ));
         assert_eq!(nav.latitude, (1.0_f64).to_degrees());

--- a/core/src/strapdown.rs
+++ b/core/src/strapdown.rs
@@ -357,11 +357,11 @@ impl From<&StrapdownState> for DVector<f64> {
 /// ```rust
 /// use strapdown::{StrapdownState, IMUData, forward};
 /// use nalgebra::Vector3;
-/// let mut state = StrapdownState::new();
-/// let imu_data = IMUData::new_from_vector(
-///    Vector3::new(0.0, 0.0, -9.81), // free fall acceleration in m/s^2
-///    Vector3::new(0.0, 0.0, 0.0) // No rotation
-/// );
+/// let mut state = StrapdownState::default();
+/// let imu_data = IMUData {
+///    accel: Vector3::new(0.0, 0.0, -9.81), // free fall acceleration in m/s^2
+///    gyro: Vector3::new(0.0, 0.0, 0.0) // No rotation
+/// };
 /// let dt = 0.1; // Example time step in seconds
 /// forward(&mut state, imu_data, dt);
 /// ```


### PR DESCRIPTION
Update the magnetic anomaly calculation to return `NAN` instead of `0.0` to avoid warnings. Refactor the `IMUData` and `StrapdownState` structures, implementing `From/Into` traits for `Vec<f64>` and `DVector<f64>`. Introduce the `NEDCovariance` struct and enhance conversions in `NavigationResult` for better navigation data handling. Refactor UKF initialization and testing parameters for improved clarity and consistency, and update documentation examples for `StrapdownState`.

Fixes #56, #55, #45, #66, #24