### PR TITLE
Add serialization for GnssDegradationConfiguration and related types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ dependencies = [
  "memchr",
  "serde",
  "serde_derive",
- "winnow",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -290,6 +290,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +339,12 @@ dependencies = [
  "r-efi",
  "wasi 0.14.4+wasi-0.2.4",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "hdf5-metno-sys"
@@ -362,6 +390,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -419,6 +457,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lock_api"
@@ -838,6 +882,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +957,28 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -966,6 +1045,10 @@ dependencies = [
  "rand 0.9.2",
  "rand_distr 0.5.1",
  "serde",
+ "serde_json",
+ "serde_yaml",
+ "tempfile",
+ "toml",
  "world_magnetic_model",
 ]
 
@@ -1008,6 +1091,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,6 +1142,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
+name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.5.40",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,6 +1186,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "uom"
@@ -1431,6 +1567,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,7 +67,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -69,7 +78,7 @@ checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -149,6 +158,12 @@ checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bitflags"
+version = "2.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bumpalo"
@@ -304,6 +319,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdf5-metno-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de20d5ba22c244493bdfefb91d8e9de08e3e58d96a792532da5e0df545aed279"
+dependencies = [
+ "libc",
+ "libloading",
+ "parking_lot",
+ "pkg-config",
+ "regex",
+ "serde",
+ "serde_derive",
+ "winreg",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,10 +393,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
+name = "libloading"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.53.3",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -444,6 +507,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
+name = "netcdf"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "377ebe63998547dd2a9713c91a42f229ac4e3fad56dd0a7385822421b882e0a5"
+dependencies = [
+ "bitflags",
+ "libc",
+ "ndarray",
+ "netcdf-sys",
+ "semver",
+]
+
+[[package]]
+name = "netcdf-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb81047c7e146ae97620a1523e5fd136d53efb2c4aaaf34222fdacad8a5913c"
+dependencies = [
+ "hdf5-metno-sys",
+ "libz-sys",
+ "parking_lot",
+ "semver",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +614,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +647,27 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"
@@ -647,6 +794,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +857,18 @@ checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -738,6 +935,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "statrs"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +975,7 @@ version = "0.1.0"
 dependencies = [
  "csv",
  "nalgebra 0.33.2",
+ "netcdf",
  "rand 0.9.2",
  "statrs",
  "strapdown-core",
@@ -868,6 +1072,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "wasi"
@@ -1020,11 +1230,51 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -1034,15 +1284,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
  "windows-link 0.1.3",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1052,9 +1314,33 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1064,9 +1350,27 @@ checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1076,15 +1380,51 @@ checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1099,6 +1439,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "serde",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -34,7 +34,11 @@ rand_distr = "0.5.1"
 serde = { version = "1.0.219", features = ["derive"] }
 world_magnetic_model = "0.4.0"
 anyhow = "1.0.99"
+serde_json = "1.0"
+serde_yaml = "0.9"
+toml = "0.7"
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
+tempfile = "3.5"
 

--- a/core/src/earth.rs
+++ b/core/src/earth.rs
@@ -381,17 +381,12 @@ pub fn meters_ned_to_dlat_dlon(lat_rad: f64, alt_m: f64, d_n: f64, d_e: f64) -> 
 /// );
 /// println!("Distance: {:.1} km", d / 1000.0);
 /// ```
-pub fn haversine_distance(
-    lat1_rad: f64,
-    lon1_rad: f64,
-    lat2_rad: f64,
-    lon2_rad: f64,
-) -> f64 {
+pub fn haversine_distance(lat1_rad: f64, lon1_rad: f64, lat2_rad: f64, lon2_rad: f64) -> f64 {
     let dlat = lat2_rad - lat1_rad;
     let dlon = lon2_rad - lon1_rad;
 
-    let a = (dlat / 2.0).sin().powi(2)
-        + lat1_rad.cos() * lat2_rad.cos() * (dlon / 2.0).sin().powi(2);
+    let a =
+        (dlat / 2.0).sin().powi(2) + lat1_rad.cos() * lat2_rad.cos() * (dlon / 2.0).sin().powi(2);
 
     let c = 2.0 * a.sqrt().atan2((1.0 - a).sqrt());
 
@@ -982,7 +977,12 @@ mod tests {
         let d = haversine_distance(0.0, 0.0, 0.0, 90_f64.to_radians());
         let expected = std::f64::consts::FRAC_PI_2 * 6_371_000.0; // R * π/2
         let err = (d - expected).abs();
-        assert!(err < 1e-6 * expected, "Error too large: got {}, expected {}", d, expected);
+        assert!(
+            err < 1e-6 * expected,
+            "Error too large: got {}, expected {}",
+            d,
+            expected
+        );
     }
 
     #[test]
@@ -991,7 +991,12 @@ mod tests {
         let d = haversine_distance(0.0, 0.0, 0.0, 180_f64.to_radians());
         let expected = std::f64::consts::PI * 6_371_000.0; // R * π
         let err = (d - expected).abs();
-        assert!(err < 1e-6 * expected, "Error too large: got {}, expected {}", d, expected);
+        assert!(
+            err < 1e-6 * expected,
+            "Error too large: got {}, expected {}",
+            d,
+            expected
+        );
     }
 
     #[test]
@@ -1004,6 +1009,10 @@ mod tests {
 
         let d = haversine_distance(nyc_lat, nyc_lon, lon_lat, lon_lon);
         // Real-world great-circle distance ~5567 km
-        assert!((d / KM - 5567.0).abs() < 50.0, "NYC-LON distance off: {} km", d / KM);
+        assert!(
+            (d / KM - 5567.0).abs() < 50.0,
+            "NYC-LON distance off: {} km",
+            d / KM
+        );
     }
 }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -1,3 +1,0 @@
-pub fn main() {
-    println!("Hello, world! this is the old strapdown");
-}

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -1,3 +1,3 @@
-pub fn main(){
+pub fn main() {
     println!("Hello, world! this is the old strapdown");
 }

--- a/core/src/messages.rs
+++ b/core/src/messages.rs
@@ -3,9 +3,13 @@ use chrono::{DateTime, Utc};
 use nalgebra::Vector3;
 use rand::SeedableRng;
 use rand_distr::{Distribution, Normal};
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::path::Path;
 
 use crate::IMUData;
-use crate::earth::{METERS_TO_DEGREES, meters_ned_to_dlat_dlon};
+use crate::earth::meters_ned_to_dlat_dlon;
 use crate::filter::{
     GPSPositionAndVelocityMeasurement, GravityAnomalyMeasurement, MagneticAnomalyMeasurement,
     RelativeAltitudeMeasurement,
@@ -45,7 +49,8 @@ use crate::sim::TestDataRecord;
 /// // Alternate 5 s ON, 15 s OFF, starting in ON state at t=0
 /// let sched = GnssScheduler::DutyCycle { on_s: 5.0, off_s: 15.0, start_phase_s: 0.0 };
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum GnssScheduler {
     /// Pass every GNSS fix through to the filter with no rate reduction.
     ///
@@ -80,6 +85,66 @@ pub enum GnssScheduler {
         /// Initial phase offset before the first ON/OFF toggle (seconds).
         start_phase_s: f64,
     },
+}
+
+#[cfg(test)]
+mod serialization_tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    fn sample_cfg() -> GnssDegradationConfig {
+        GnssDegradationConfig {
+            scheduler: GnssScheduler::PassThrough,
+            fault: GnssFaultModel::Degraded {
+                rho_pos: 0.99,
+                sigma_pos_m: 3.0,
+                rho_vel: 0.95,
+                sigma_vel_mps: 0.3,
+                r_scale: 5.0,
+            },
+            seed: 42,
+        }
+    }
+
+    #[test]
+    fn json_roundtrip() {
+        let cfg = sample_cfg();
+        let f = NamedTempFile::new().unwrap();
+        let path = f.path().with_extension("json");
+        cfg.to_json(&path).unwrap();
+        let loaded = GnssDegradationConfig::from_json(&path).unwrap();
+        assert_eq!(cfg.seed, loaded.seed);
+    }
+
+    #[test]
+    fn yaml_roundtrip() {
+        let cfg = sample_cfg();
+        let f = NamedTempFile::new().unwrap();
+        let path = f.path().with_extension("yaml");
+        cfg.to_yaml(&path).unwrap();
+        let loaded = GnssDegradationConfig::from_yaml(&path).unwrap();
+        assert_eq!(cfg.seed, loaded.seed);
+    }
+
+    #[test]
+    fn toml_roundtrip() {
+        let cfg = sample_cfg();
+        let f = NamedTempFile::new().unwrap();
+        let path = f.path().with_extension("toml");
+        cfg.to_toml(&path).unwrap();
+        let loaded = GnssDegradationConfig::from_toml(&path).unwrap();
+        assert_eq!(cfg.seed, loaded.seed);
+    }
+
+    #[test]
+    fn generic_dispatch_roundtrip() {
+        let cfg = sample_cfg();
+        let f = NamedTempFile::new().unwrap();
+        let path = f.path().with_extension("json");
+        cfg.to_file(&path).unwrap();
+        let loaded = GnssDegradationConfig::from_file(&path).unwrap();
+        assert_eq!(cfg.seed, loaded.seed);
+    }
 }
 /// Models how GNSS measurement *content* is corrupted before it reaches the filter.
 ///
@@ -144,7 +209,8 @@ pub enum GnssScheduler {
 ///     GnssFaultModel::Hijack { offset_n_m: 50.0, offset_e_m: 0.0, start_s: 120.0, duration_s: 60.0 },
 /// ]);
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum GnssFaultModel {
     /// No corruption; GNSS fixes are passed through unchanged.
     None,
@@ -236,7 +302,7 @@ pub enum GnssFaultModel {
 ///     seed: 42,
 /// };
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GnssDegradationConfig {
     /// Scheduler that determines when GNSS measurements are emitted
     /// (e.g., pass-through, fixed interval, or duty-cycled).
@@ -251,6 +317,74 @@ pub struct GnssDegradationConfig {
     /// Use the same seed to repeat scenarios exactly; change it to get a new
     /// realization of stochastic processes such as AR(1) degradation.
     pub seed: u64,
+}
+
+impl GnssDegradationConfig {
+    /// Write the configuration to a JSON file (pretty-printed).
+    pub fn to_json<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
+        let file = File::create(path)?;
+        serde_json::to_writer_pretty(file, self).map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
+
+    /// Read the configuration from a JSON file.
+    pub fn from_json<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        let file = File::open(path)?;
+        serde_json::from_reader(file).map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
+    /// Write the configuration as YAML.
+    pub fn to_yaml<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
+        let mut file = File::create(path)?;
+        let s = serde_yaml::to_string(self).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        file.write_all(s.as_bytes())
+    }
+
+    /// Read the configuration from YAML.
+    pub fn from_yaml<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        let file = File::open(path)?;
+        serde_yaml::from_reader(file).map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
+    /// Write the configuration as TOML.
+    pub fn to_toml<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
+        let mut file = File::create(path)?;
+        let s = toml::to_string(self).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        file.write_all(s.as_bytes())
+    }
+    /// Read the configuration from TOML.
+    pub fn from_toml<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        let mut s = String::new();
+        let mut file = File::open(path)?;
+        file.read_to_string(&mut s)?;
+        toml::from_str(&s).map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
+    /// Generic write: choose format by file extension (.json/.yaml/.yml/.toml)
+    pub fn to_file<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
+        let p = path.as_ref();
+        let ext = p
+            .extension()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_lowercase());
+        match ext.as_deref() {
+            Some("json") => self.to_json(p),
+            Some("yaml") | Some("yml") => self.to_yaml(p),
+            Some("toml") => self.to_toml(p),
+            _ => Err(io::Error::new(io::ErrorKind::InvalidInput, "unsupported file extension")),
+        }
+    }
+
+    /// Generic read: choose format by file extension (.json/.yaml/.yml/.toml)
+    pub fn from_file<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        let p = path.as_ref();
+        let ext = p
+            .extension()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_lowercase());
+        match ext.as_deref() {
+            Some("json") => Self::from_json(p),
+            Some("yaml") | Some("yml") => Self::from_yaml(p),
+            Some("toml") => Self::from_toml(p),
+            _ => Err(io::Error::new(io::ErrorKind::InvalidInput, "unsupported file extension")),
+        }
+    }
 }
 
 /// A simulation event delivered to the filter in time order.

--- a/core/src/messages.rs
+++ b/core/src/messages.rs
@@ -5,7 +5,7 @@ use rand::SeedableRng;
 use rand_distr::{Distribution, Normal};
 
 use crate::IMUData;
-use crate::earth::{meters_ned_to_dlat_dlon, METERS_TO_DEGREES};
+use crate::earth::{METERS_TO_DEGREES, meters_ned_to_dlat_dlon};
 use crate::filter::{
     GPSPositionAndVelocityMeasurement, GravityAnomalyMeasurement, MagneticAnomalyMeasurement,
     RelativeAltitudeMeasurement,
@@ -473,7 +473,7 @@ impl FaultState {
 ///
 /// ```ignore
 /// use rand::SeedableRng;
-/// 
+///
 /// let mut x = 0.0;
 /// let mut rng = SeedableRng::seed_from_u64(42);
 /// for _ in 0..5 {
@@ -713,7 +713,7 @@ fn apply_fault(
     }
 }
 // --------------------------- public API ---------------------------
-/// Build a time-ordered event stream from recorded data and a GNSS degradation 
+/// Build a time-ordered event stream from recorded data and a GNSS degradation
 /// configuration.
 ///
 /// This function converts raw `records` into a vector of [`Event`]s suitable
@@ -886,8 +886,8 @@ pub fn build_event_stream(records: &[TestDataRecord], cfg: &GnssDegradationConfi
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::{TimeZone, Utc};
     use assert_approx_eq::assert_approx_eq;
+    use chrono::{TimeZone, Utc};
 
     fn create_test_records(count: usize, interval_secs: f64) -> Vec<TestDataRecord> {
         let base_time = Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 0).unwrap();
@@ -994,7 +994,11 @@ mod tests {
     #[test]
     fn test_duty_cycle_scheduler() {
         let records = create_test_records(60, 1.0); // 60 records, 1s apart, 60 seconds total
-        assert!(records.len() == 60, "{}", format!("Expected 60 records, found: {}", records.len()));
+        assert!(
+            records.len() == 60,
+            "{}",
+            format!("Expected 60 records, found: {}", records.len())
+        );
 
         let config = GnssDegradationConfig {
             scheduler: GnssScheduler::DutyCycle {
@@ -1005,7 +1009,7 @@ mod tests {
             fault: GnssFaultModel::None,
             seed: 42,
         };
-        // 
+        //
         let events = build_event_stream(&records, &config);
         //assert!(events.len() == 60, "{}", format!("Expected 60 events, found: {}", events.len()));
         // We should only have GNSS events when turning ON
@@ -1018,7 +1022,11 @@ mod tests {
         // We initialize off of the first event and only get GNSS updates every two seconds starting from 1.0
         // (60 - 1) // 2 = 29
         assert!(gnss_events.len() >= 2);
-        assert!(gnss_events.len() == 29, "{}", format!("Expected 29 GNSS events, found: {}", gnss_events.len()));
+        assert!(
+            gnss_events.len() == 29,
+            "{}",
+            format!("Expected 29 GNSS events, found: {}", gnss_events.len())
+        );
 
         // Extract elapsed_s from GNSS events and verify they occur at expected times
         let gnss_times: Vec<f64> = gnss_events
@@ -1126,17 +1134,14 @@ mod tests {
 
         // zero “truth” velocity
         let (_lat, _lon, _alt, vn_c, ve_c, _hstd, _vstd) = apply_fault(
-            &fault, &mut st,
-            /*t*/ 10.0, /*dt*/ 1.0,
-            /*lat_deg*/ 40.0, /*lon_deg*/ -75.0, /*alt_m*/ 0.0,
-            /*vn_mps*/ 0.0,   /*ve_mps*/ 0.0,
+            &fault, &mut st, /*t*/ 10.0, /*dt*/ 1.0, /*lat_deg*/ 40.0,
+            /*lon_deg*/ -75.0, /*alt_m*/ 0.0, /*vn_mps*/ 0.0, /*ve_mps*/ 0.0,
             /*horiz_std_m*/ 3.0, /*vert_std_m*/ 5.0, /*vel_std_mps*/ 0.2,
         );
 
-        assert_approx_eq!(vn_c,  0.02, 0.001);
+        assert_approx_eq!(vn_c, 0.02, 0.001);
         assert_approx_eq!(ve_c, -0.01, 0.001);
     }
-
 
     #[test]
     fn test_hijack_fault_model() {
@@ -1183,8 +1188,6 @@ mod tests {
             }
         }
     }
-
-    
 
     #[test]
     fn test_combo_fault_model() {

--- a/core/src/sim.rs
+++ b/core/src/sim.rs
@@ -18,7 +18,7 @@ use std::fmt::Display;
 use std::io::{self};
 use std::path::Path;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use chrono::{DateTime, Datelike, Duration, Utc};
 use nalgebra::{DMatrix, DVector, Vector3};
 use serde::{Deserialize, Serialize};
@@ -395,19 +395,9 @@ impl NavigationResult {
 ///
 /// # Returns
 /// A NavigationResult struct containing the navigation solution.
-impl
-    From<(
-        &DateTime<Utc>,
-        &DVector<f64>,
-        &DMatrix<f64>,
-    )> for NavigationResult
-{
+impl From<(&DateTime<Utc>, &DVector<f64>, &DMatrix<f64>)> for NavigationResult {
     fn from(
-        (timestamp, state, covariance): (
-            &DateTime<Utc>,
-            &DVector<f64>,
-            &DMatrix<f64>,
-        ),
+        (timestamp, state, covariance): (&DateTime<Utc>, &DVector<f64>, &DMatrix<f64>),
     ) -> Self {
         assert!(
             state.len() == 15,
@@ -481,12 +471,7 @@ impl
 /// # Returns
 /// A NavigationResult struct containing the navigation solution.
 impl From<(&DateTime<Utc>, &UKF)> for NavigationResult {
-    fn from(
-        (timestamp, ukf): (
-            &DateTime<Utc>,
-            &UKF,
-        ),
-    ) -> Self {
+    fn from((timestamp, ukf): (&DateTime<Utc>, &UKF)) -> Self {
         let state = &ukf.get_mean();
         let covariance = ukf.get_covariance();
         NavigationResult {
@@ -714,25 +699,31 @@ pub fn closed_loop(ukf: &mut UKF, stream: EventStream) -> anyhow::Result<Vec<Nav
         match event {
             Event::Imu { dt_s, imu, .. } => {
                 ukf.predict(imu, dt_s);
-                if let Err(e) = monitor.check(ukf.get_mean().as_slice(), &ukf.get_covariance(), None) {
+                if let Err(e) =
+                    monitor.check(ukf.get_mean().as_slice(), &ukf.get_covariance(), None)
+                {
                     // log::error!("Health fail after predict at {} (#{i}): {e}", ts);
                     bail!(e);
                 }
-            },
+            }
             Event::Gnss { meas, .. } => {
                 ukf.update(meas);
-                if let Err(e) = monitor.check(ukf.get_mean().as_slice(), &ukf.get_covariance(), None) {
+                if let Err(e) =
+                    monitor.check(ukf.get_mean().as_slice(), &ukf.get_covariance(), None)
+                {
                     // log::error!("Health fail after GNSS update at {} (#{i}): {e}", ts);
                     bail!(e);
                 }
-            },
+            }
             Event::Altitude { meas, .. } => {
                 ukf.update(meas);
-                if let Err(e) = monitor.check(ukf.get_mean().as_slice(), &ukf.get_covariance(), None) {
+                if let Err(e) =
+                    monitor.check(ukf.get_mean().as_slice(), &ukf.get_covariance(), None)
+                {
                     // log::error!("Health fail after altitude update at {} (#{i}): {e}", ts);
                     bail!(e);
                 }
-            },
+            }
             Event::GravityAnomaly { meas, elapsed_s } => {
                 println!("Gravity anomaly detected: {:?} at {:?}s", meas, elapsed_s);
             }
@@ -907,13 +898,13 @@ pub mod health {
 
     #[derive(Clone, Debug)]
     pub struct HealthLimits {
-        pub lat_rad: (f64, f64),   // [-90°, +90°]
-        pub lon_rad: (f64, f64),   // [-180°, +180°]
-        pub alt_m:   (f64, f64),   // e.g., [-500, 15000]
-        pub speed_mps_max: f64,    // e.g., 120 m/s (road/low-altitude aircraft)
-        pub cov_diag_max: f64,     // e.g., 1e6
-        pub cond_max: f64,         // e.g., 1e12 (optional)
-        pub nis_pos_max: f64,      // e.g., 100 (huge outlier)
+        pub lat_rad: (f64, f64),        // [-90°, +90°]
+        pub lon_rad: (f64, f64),        // [-180°, +180°]
+        pub alt_m: (f64, f64),          // e.g., [-500, 15000]
+        pub speed_mps_max: f64,         // e.g., 120 m/s (road/low-altitude aircraft)
+        pub cov_diag_max: f64,          // e.g., 1e6
+        pub cond_max: f64,              // e.g., 1e12 (optional)
+        pub nis_pos_max: f64,           // e.g., 100 (huge outlier)
         pub nis_pos_consec_fail: usize, // e.g., 20
     }
 
@@ -922,7 +913,7 @@ pub mod health {
             Self {
                 lat_rad: (-std::f64::consts::FRAC_PI_2, std::f64::consts::FRAC_PI_2),
                 lon_rad: (-std::f64::consts::PI, std::f64::consts::PI),
-                alt_m:   (-500.0, 15000.0),
+                alt_m: (-500.0, 15000.0),
                 speed_mps_max: 120.0,
                 cov_diag_max: 1e6,
                 cond_max: 1e12,
@@ -939,35 +930,56 @@ pub mod health {
     }
 
     impl HealthMonitor {
-        pub fn new(limits: HealthLimits) -> Self { Self { limits, consec_nis_pos_fail: 0 } }
+        pub fn new(limits: HealthLimits) -> Self {
+            Self {
+                limits,
+                consec_nis_pos_fail: 0,
+            }
+        }
 
         /// Call after **every event** (predict or update). Provide optional NIS when you have a GNSS update.
         pub fn check(
             &mut self,
-            x: &[f64],             // your mean_state slice
+            x: &[f64], // your mean_state slice
             p: &nalgebra::DMatrix<f64>,
             maybe_nis_pos: Option<f64>,
         ) -> Result<()> {
             // 1) Finite checks
-            if !x.iter().all(|v| v.is_finite()) { bail!("Non-finite state detected"); }
-            if !p.iter().all(|v| v.is_finite()) { bail!("Non-finite covariance detected"); }
+            if !x.iter().all(|v| v.is_finite()) {
+                bail!("Non-finite state detected");
+            }
+            if !p.iter().all(|v| v.is_finite()) {
+                bail!("Non-finite covariance detected");
+            }
 
             // 2) Basic bounds (lat, lon, alt)
-            let lat = x[0]; let lon = x[1]; let alt = x[2];
-            if lat < self.limits.lat_rad.0 || lat > self.limits.lat_rad.1 { bail!("Latitude out of range: {lat}"); }
-            if lon < self.limits.lon_rad.0 || lon > self.limits.lon_rad.1 { bail!("Longitude out of range: {lon}"); }
-            if alt < self.limits.alt_m.0   || alt > self.limits.alt_m.1   { bail!("Altitude out of range: {alt} m"); }
+            let lat = x[0];
+            let lon = x[1];
+            let alt = x[2];
+            if lat < self.limits.lat_rad.0 || lat > self.limits.lat_rad.1 {
+                bail!("Latitude out of range: {lat}");
+            }
+            if lon < self.limits.lon_rad.0 || lon > self.limits.lon_rad.1 {
+                bail!("Longitude out of range: {lon}");
+            }
+            if alt < self.limits.alt_m.0 || alt > self.limits.alt_m.1 {
+                bail!("Altitude out of range: {alt} m");
+            }
 
             // 3) Speed sanity (assumes NED velocities at indices 3..=5)
-            let v2 = x[3]*x[3] + x[4]*x[4] + x[5]*x[5];
+            let v2 = x[3] * x[3] + x[4] * x[4] + x[5] * x[5];
             if v2.is_finite() && v2.sqrt() > self.limits.speed_mps_max {
                 bail!("Speed exceeded: {:.2} m/s", v2.sqrt());
             }
 
             // 4) Covariance sanity: diagonals and simple SPD probe
             for i in 0..p.nrows().min(p.ncols()) {
-                if p[(i,i)].is_sign_negative() { bail!("Negative variance on diagonal: idx={i}, val={}", p[(i,i)]); }
-                if p[(i,i)] > self.limits.cov_diag_max { bail!("Variance too large on diagonal idx={i}: {}", p[(i,i)]); }
+                if p[(i, i)].is_sign_negative() {
+                    bail!("Negative variance on diagonal: idx={i}, val={}", p[(i, i)]);
+                }
+                if p[(i, i)] > self.limits.cov_diag_max {
+                    bail!("Variance too large on diagonal idx={i}: {}", p[(i, i)]);
+                }
             }
             // (Optional) rough condition estimate via Frobenius norm and inverse
             // Skip if too expensive; enable only for debugging.
@@ -984,8 +996,12 @@ pub mod health {
                 if nis_pos > self.limits.nis_pos_max {
                     self.consec_nis_pos_fail += 1;
                     if self.consec_nis_pos_fail >= self.limits.nis_pos_consec_fail {
-                        bail!("Consecutive NIS exceedances: {} (> {}), last NIS={}",
-                            self.consec_nis_pos_fail, self.limits.nis_pos_consec_fail, nis_pos);
+                        bail!(
+                            "Consecutive NIS exceedances: {} (> {}), last NIS={}",
+                            self.consec_nis_pos_fail,
+                            self.limits.nis_pos_consec_fail,
+                            nis_pos
+                        );
                     }
                 } else {
                     self.consec_nis_pos_fail = 0;

--- a/examples/configs/gnss_degradation.json
+++ b/examples/configs/gnss_degradation.json
@@ -1,0 +1,5 @@
+{
+  "scheduler": { "kind": "fixed_interval", "interval_s": 10.0, "phase_s": 0.0 },
+  "fault": { "kind": "degraded", "rho_pos": 0.99, "sigma_pos_m": 3.0, "rho_vel": 0.95, "sigma_vel_mps": 0.3, "r_scale": 5.0 },
+  "seed": 42
+}

--- a/examples/configs/gnss_degradation.toml
+++ b/examples/configs/gnss_degradation.toml
@@ -1,0 +1,14 @@
+[scheduler]
+kind = "fixed_interval"
+interval_s = 10.0
+phase_s = 0.0
+
+[fault]
+kind = "degraded"
+rho_pos = 0.99
+sigma_pos_m = 3.0
+rho_vel = 0.95
+sigma_vel_mps = 0.3
+r_scale = 5.0
+
+seed = 42

--- a/examples/configs/gnss_degradation.yaml
+++ b/examples/configs/gnss_degradation.yaml
@@ -1,0 +1,12 @@
+scheduler:
+  kind: fixed_interval
+  interval_s: 10.0
+  phase_s: 0.0
+fault:
+  kind: degraded
+  rho_pos: 0.99
+  sigma_pos_m: 3.0
+  rho_vel: 0.95
+  sigma_vel_mps: 0.3
+  r_scale: 5.0
+seed: 42

--- a/geonav/Cargo.toml
+++ b/geonav/Cargo.toml
@@ -10,3 +10,4 @@ rand = { workspace = true }
 csv = { workspace = true }
 strapdown-core = { version = "0.4.0", path = "../core" }
 statrs = "0.18.0"
+netcdf = "0.11.0"

--- a/geonav/src/lib.rs
+++ b/geonav/src/lib.rs
@@ -414,7 +414,8 @@ impl MeasurementModel for GeophysicalMeasurement<'_> {
         for (i, sigma_point) in state_sigma_points.column_iter().enumerate() {
             measurement_sigma_points[i] = self
                 .map
-                .get_point(&sigma_point[0].to_degrees(), &sigma_point[1].to_degrees()).unwrap();
+                .get_point(&sigma_point[0].to_degrees(), &sigma_point[1].to_degrees())
+                .unwrap();
         }
         measurement_sigma_points
     }
@@ -557,16 +558,7 @@ pub fn run_geophysical_navigation(
         measurement_standard_deviation,
     );
     // Set the initial result to the UKF initial state
-    results.push(NavigationResult::from((
-        &records[0].time,
-        &ukf,
-        &IMUData {
-            accel: Vector3::new(records[0].acc_x, records[0].acc_y, records[0].acc_z),
-            gyro: Vector3::new(records[0].gyro_x, records[0].gyro_y, records[0].gyro_z),
-        },
-        &Vector3::new(records[0].mag_x, records[0].mag_y, records[0].mag_z),
-        &records[0].pressure,
-    )));
+    results.push(NavigationResult::from((&records[0].time, &ukf)));
     // Begin processing
     let mut previous_timestamp = records[0].time;
     // Iterate through the records, updating the UKF with each IMU measurement
@@ -674,13 +666,7 @@ pub fn run_geophysical_navigation(
             }
         }
         // Store the current state and covariance in results
-        results.push(NavigationResult::from((
-            &current_timestamp,
-            &ukf,
-            &imu_data,
-            &Vector3::new(record.mag_x, record.mag_y, record.mag_z),
-            &record.pressure,
-        )));
+        results.push(NavigationResult::from((&current_timestamp, &ukf)));
         i += 1;
         previous_timestamp = current_timestamp;
     }

--- a/pixi.toml
+++ b/pixi.toml
@@ -10,13 +10,13 @@ license = "MIT"
 [activation.env]
 RUST_BACKTRACE = "1"
 # These might need to be absolute pathes
-# HDF5_DIR = ".pixi/envs/default"
-# RUSTFLAGS="-C link-args=-Wl,-rpath, .pixi/envs/default/include/lib"
+HDF5_DIR = "${PIXI_PROJECT_ROOT}/.pixi/envs/default"
+RUSTFLAGS="-C link-args=-Wl,-rpath,.pixi/envs/default/include/lib"
 
 [tasks]
 build = "cargo build --workspace --release"
 lint = "ruff check --select I --fix && cargo clippy --all-targets --all-features -- -D warnings"
-fmt = "ruff format . && cargo fmt --fix"
+fmt = "ruff format . && cargo fmt"
 preprocess = "python scripts/preprocess.py --input_dir data/raw/ --output_dir data/input/"
 #test = "pytest --cov=geophysical_nav --cov-report=xml --cov-report=html"
 

--- a/scripts/degraded.py
+++ b/scripts/degraded.py
@@ -30,7 +30,9 @@ def run_degraded(
             if input_file.endswith(".csv"):
                 fqy = os.path.split(root)[-1]
                 base = os.path.splitext(os.path.basename(input_file))[0]
-                output_file = os.path.join(output_dir, f"{str(gps_interval)}s", fqy, f"{base}.csv")
+                output_file = os.path.join(
+                    output_dir, f"{str(gps_interval)}s", fqy, f"{base}.csv"
+                )
                 os.makedirs(os.path.dirname(output_file), exist_ok=True)
                 print(f"Processing: {input_file}")
                 cmd = f"strapdown --mode closed-loop --input {os.path.join(root, input_file)} --output {output_file} --gps-interval {gps_interval}"
@@ -41,14 +43,18 @@ def run_degraded(
                 try:
                     ret = os.system(cmd)
                     if ret != 0:
-                        print(f"Skipping {input_file} due to error: strapdown exited with code {ret}")
+                        print(
+                            f"Skipping {input_file} due to error: strapdown exited with code {ret}"
+                        )
                 except Exception as err:
                     print(f"Skipping {input_file} due to error: {err}")
     print("Degraded mechanization data sets created.")
 
 
 def main():
-    parser = ArgumentParser(description="Create degraded data sets using strapdown CLI.")
+    parser = ArgumentParser(
+        description="Create degraded data sets using strapdown CLI."
+    )
     parser.add_argument(
         "--input_dir",
         type=str,
@@ -62,8 +68,12 @@ def main():
         help="Output directory for degraded data sets.",
     )
     parser.add_argument("--gps_interval", type=int, required=True, help="GPS interval.")
-    parser.add_argument("--gps_accuracy", type=float, required=True, help="GPS accuracy.")
-    parser.add_argument("--gps_spoofing", type=float, required=True, help="GPS spoofing.")
+    parser.add_argument(
+        "--gps_accuracy", type=float, required=True, help="GPS accuracy."
+    )
+    parser.add_argument(
+        "--gps_spoofing", type=float, required=True, help="GPS spoofing."
+    )
     args = parser.parse_args()
     run_degraded(
         args.input_dir,

--- a/scripts/get_maps.py
+++ b/scripts/get_maps.py
@@ -49,7 +49,9 @@ def inflate_bounds(
 
 
 def get_maps(
-    input_file_directory: str, buffer: float = 0.25, output_directory: str = os.path.join("data", "input")
+    input_file_directory: str,
+    buffer: float = 0.25,
+    output_directory: str = os.path.join("data", "input"),
 ) -> None:
     """
     Goes through the target directory to download the geophysical maps.
@@ -68,18 +70,28 @@ def get_maps(
         lon_min, lon_max = df["longitude"].min(), df["longitude"].max()
         lat_min, lat_max = df["latitude"].min(), df["latitude"].max()
 
-        lon_min, lon_max, lat_min, lat_max = inflate_bounds(lon_min, lon_max, lat_min, lat_max, buffer)
+        lon_min, lon_max, lat_min, lat_max = inflate_bounds(
+            lon_min, lon_max, lat_min, lat_max, buffer
+        )
 
         print(f"  Longitude bounds: {lon_min} to {lon_max}")
         print(f"  Latitude bounds: {lat_min} to {lat_max}")
 
         # Download the maps
-        relief = load_earth_relief(resolution="15s", region=[lon_min, lon_max, lat_min, lat_max])
-        relief.to_netcdf(os.path.join(output_directory, basename.replace(".csv", "_relief.nc")))
+        relief = load_earth_relief(
+            resolution="15s", region=[lon_min, lon_max, lat_min, lat_max]
+        )
+        relief.to_netcdf(
+            os.path.join(output_directory, basename.replace(".csv", "_relief.nc"))
+        )
         print(f"  Downloaded relief map: {relief.data.shape}.")
 
-        gravity = load_earth_free_air_anomaly(resolution="01m", region=[lon_min, lon_max, lat_min, lat_max])
-        gravity.to_netcdf(os.path.join(output_directory, basename.replace(".csv", "_gravity.nc")))
+        gravity = load_earth_free_air_anomaly(
+            resolution="01m", region=[lon_min, lon_max, lat_min, lat_max]
+        )
+        gravity.to_netcdf(
+            os.path.join(output_directory, basename.replace(".csv", "_gravity.nc"))
+        )
         print(f"  Downloaded gravity map: {gravity.data.shape}.")
 
         magnetic = load_earth_magnetic_anomaly(
@@ -87,12 +99,16 @@ def get_maps(
             region=[lon_min, lon_max, lat_min, lat_max],
             data_source="wdmam",
         )
-        magnetic.to_netcdf(os.path.join(output_directory, basename.replace(".csv", "_magnetic.nc")))
+        magnetic.to_netcdf(
+            os.path.join(output_directory, basename.replace(".csv", "_magnetic.nc"))
+        )
         print(f"  Downloaded magnetic map: {magnetic.data.shape}.")
 
 
 if __name__ == "__main__":
-    parser = ArgumentParser(description="Download geophysical maps from the GMT servers.")
+    parser = ArgumentParser(
+        description="Download geophysical maps from the GMT servers."
+    )
     parser.add_argument(
         "--buffer",
         type=float,

--- a/scripts/plot.py
+++ b/scripts/plot.py
@@ -31,7 +31,9 @@ def inflate_bounds(
     return new_min_x, new_min_y, new_max_x, new_max_y
 
 
-def plot_route(cleaned_data: pd.DataFrame, output_path: str, title: Optional[str] = None):
+def plot_route(
+    cleaned_data: pd.DataFrame, output_path: str, title: Optional[str] = None
+):
     """
     Plot the route from cleaned data and save to output_path.
     """
@@ -39,7 +41,9 @@ def plot_route(cleaned_data: pd.DataFrame, output_path: str, title: Optional[str
     east_lon = cleaned_data["longitude"].max()
     south_lat = cleaned_data["latitude"].min()
     north_lat = cleaned_data["latitude"].max()
-    west_lon, south_lat, east_lon, north_lat = inflate_bounds(west_lon, south_lat, east_lon, north_lat, 0.1)
+    west_lon, south_lat, east_lon, north_lat = inflate_bounds(
+        west_lon, south_lat, east_lon, north_lat, 0.1
+    )
     extent = [west_lon, east_lon, south_lat, north_lat]
     request = cimgt.GoogleTiles()
     ax = plt.axes(projection=request.crs)
@@ -60,7 +64,9 @@ def plot_route(cleaned_data: pd.DataFrame, output_path: str, title: Optional[str
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Plot route(s) from cleaned data CSV file(s).")
+    parser = argparse.ArgumentParser(
+        description="Plot route(s) from cleaned data CSV file(s)."
+    )
     parser.add_argument(
         "--input",
         type=str,
@@ -73,7 +79,9 @@ def main():
         required=True,
         help="Output directory for route plot images.",
     )
-    parser.add_argument("--title", type=str, default=None, help="Optional title for the plot(s).")
+    parser.add_argument(
+        "--title", type=str, default=None, help="Optional title for the plot(s)."
+    )
     args = parser.parse_args()
     os.makedirs(args.output, exist_ok=True)
     if os.path.isfile(args.input):
@@ -83,7 +91,9 @@ def main():
             out_path = os.path.join(args.output, out_name)
             plot_route(df, out_path, title=args.title)
         else:
-            print(f"Input file {args.input} does not contain longitude/latitude columns.")
+            print(
+                f"Input file {args.input} does not contain longitude/latitude columns."
+            )
     elif os.path.isdir(args.input):
         for root, _, files in os.walk(args.input):
             for file in tqdm(files):

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -26,35 +26,59 @@ def clean_phone_data(dataset_path: str) -> pd.DataFrame:
     assert os.path.exists(dataset_path), f"File {dataset_path} does not exist."
     # Assert the needed .csv files exist
     # assert os.path.exists(os.path.join(dataset_path, "Accelerometer.csv")), "Accelerometer.csv does not exist."
-    assert os.path.exists(os.path.join(dataset_path, "Gyroscope.csv")), "Gyroscope.csv does not exist."
+    assert os.path.exists(os.path.join(dataset_path, "Gyroscope.csv")), (
+        "Gyroscope.csv does not exist."
+    )
     # Check to make sure that the trajectory is of sufficient length (>=300 seconds)
     gyro = pd.read_csv(os.path.join(dataset_path, "Gyroscope.csv"), index_col=0)
     assert gyro["seconds_elapsed"].max() >= 300, (
         f"Trajectory is too short. Minimum required is 300 seconds. Trajectory is {gyro['seconds_elapsed'].max()} seconds."
     )
-    assert os.path.exists(os.path.join(dataset_path, "Magnetometer.csv")), "Magnetometer.csv does not exist."
-    assert os.path.exists(os.path.join(dataset_path, "Barometer.csv")), "Barometer.csv does not exist."
-    assert os.path.exists(os.path.join(dataset_path, "Gravity.csv")), "Gravity.csv does not exist."
+    assert os.path.exists(os.path.join(dataset_path, "Magnetometer.csv")), (
+        "Magnetometer.csv does not exist."
+    )
+    assert os.path.exists(os.path.join(dataset_path, "Barometer.csv")), (
+        "Barometer.csv does not exist."
+    )
+    assert os.path.exists(os.path.join(dataset_path, "Gravity.csv")), (
+        "Gravity.csv does not exist."
+    )
     try:
-        assert os.path.exists(os.path.join(dataset_path, "LocationGps.csv")), "LocationGps.csv does not exist."
+        assert os.path.exists(os.path.join(dataset_path, "LocationGps.csv")), (
+            "LocationGps.csv does not exist."
+        )
     except AssertionError:
-        assert os.path.exists(os.path.join(dataset_path, "Location.csv")), "Location.csv does not exist."
-    assert os.path.exists(os.path.join(dataset_path, "Orientation.csv")), "Orientation.csv does not exist."
+        assert os.path.exists(os.path.join(dataset_path, "Location.csv")), (
+            "Location.csv does not exist."
+        )
+    assert os.path.exists(os.path.join(dataset_path, "Orientation.csv")), (
+        "Orientation.csv does not exist."
+    )
     # Read in raw data
     gyroscope = pd.read_csv(os.path.join(dataset_path, "Gyroscope.csv"), index_col=0)
-    magnetometer = pd.read_csv(os.path.join(dataset_path, "Magnetometer.csv"), index_col=0)
+    magnetometer = pd.read_csv(
+        os.path.join(dataset_path, "Magnetometer.csv"), index_col=0
+    )
     barometer = pd.read_csv(os.path.join(dataset_path, "Barometer.csv"), index_col=0)
     gravity = pd.read_csv(os.path.join(dataset_path, "Gravity.csv"), index_col=0)
-    orientation = pd.read_csv(os.path.join(dataset_path, "Orientation.csv"), index_col=0)
+    orientation = pd.read_csv(
+        os.path.join(dataset_path, "Orientation.csv"), index_col=0
+    )
     try:
-        location = pd.read_csv(os.path.join(dataset_path, "LocationGps.csv"), index_col=0)
+        location = pd.read_csv(
+            os.path.join(dataset_path, "LocationGps.csv"), index_col=0
+        )
     except FileNotFoundError:
         location = pd.read_csv(os.path.join(dataset_path, "Location.csv"), index_col=0)
     try:
-        accelerometer = pd.read_csv(os.path.join(dataset_path, "TotalAcceleration.csv"), index_col=0)
+        accelerometer = pd.read_csv(
+            os.path.join(dataset_path, "TotalAcceleration.csv"), index_col=0
+        )
     except FileNotFoundError as e:
         print(f"TotalAcceleration.csv not found, using Accelerometer.csv instead: {e}")
-        accelerometer = pd.read_csv(os.path.join(dataset_path, "Accelerometer.csv"), index_col=0)
+        accelerometer = pd.read_csv(
+            os.path.join(dataset_path, "Accelerometer.csv"), index_col=0
+        )
         accelerometer["x"] += gravity["x"]
         accelerometer["y"] += gravity["y"]
         accelerometer["z"] += gravity["z"]
@@ -75,8 +99,12 @@ def clean_phone_data(dataset_path: str) -> pd.DataFrame:
     location.drop(columns=["seconds_elapsed"], inplace=True)
     orientation.drop(columns=["seconds_elapsed"], inplace=True)
     # Rename columns
-    magnetometer = magnetometer.rename(columns={"x": "mag_x", "y": "mag_y", "z": "mag_z"})
-    accelerometer = accelerometer.rename(columns={"x": "acc_x", "y": "acc_y", "z": "acc_z"})
+    magnetometer = magnetometer.rename(
+        columns={"x": "mag_x", "y": "mag_y", "z": "mag_z"}
+    )
+    accelerometer = accelerometer.rename(
+        columns={"x": "acc_x", "y": "acc_y", "z": "acc_z"}
+    )
     gyroscope = gyroscope.rename(columns={"x": "gyro_x", "y": "gyro_y", "z": "gyro_z"})
     gravity = gravity.rename(columns={"x": "grav_x", "y": "grav_y", "z": "grav_z"})
     # Merge dataframes
@@ -122,7 +150,9 @@ def preprocess(args):
     datasets = os.listdir(args.input_dir)
     # Check to see if datasets in empty, if true ask if the user would lke to download the dataset
     if not datasets:
-        download = input("No datasets found. Would you like to download the dataset? (y/n): ")
+        download = input(
+            "No datasets found. Would you like to download the dataset? (y/n): "
+        )
         if download.lower() == "y":
             # Code to download the dataset goes here
             pass
@@ -132,7 +162,9 @@ def preprocess(args):
 
     # os.makedirs(os.path.join("data", "cleaned"), exist_ok=True)
     os.makedirs(args.output_dir, exist_ok=True)
-    print(f"Preprocessing data from {args.input_dir}. Output will be saved to {args.output_dir}.")
+    print(
+        f"Preprocessing data from {args.input_dir}. Output will be saved to {args.output_dir}."
+    )
 
     def process_dataset(dataset):
         # for dataset in datasets:
@@ -173,7 +205,9 @@ def main() -> None:
         help="Output directory for the cleaned data.",
     )
     args = parser.parse_args()
-    assert os.path.exists(args.input_dir), f"Input directory {args.input_dir} does not exist."
+    assert os.path.exists(args.input_dir), (
+        f"Input directory {args.input_dir} does not exist."
+    )
     preprocess(args)
 
 

--- a/scripts/truth.py
+++ b/scripts/truth.py
@@ -19,7 +19,9 @@ def run_truth_mechanization(input_dir: str, output_dir: str):
                 output_file = os.path.join(output_dir, f"{base}_truth.csv")
                 print(f"Processing: {input_file}")
                 try:
-                    os.system(f"strapdown --mode closed-loop --input {input_file} --output {output_file}")
+                    os.system(
+                        f"strapdown --mode closed-loop --input {input_file} --output {output_file}"
+                    )
                 except Exception as err:
                     print(f"Skipping {input_file} due to error: {err}")
     print("Truth mechanization data sets created.")


### PR DESCRIPTION
Serialization support has been added for GnssDegradationConfiguration and other necessary types in the `messages` module. This enhancement allows configurations to be easily saved to and loaded from files, streamlining the initialization of simulations. Additional commits include workspace reconfiguration, input file additions, and a linting pass.

Fixes #84